### PR TITLE
Day-1: Lean4 skeleton + README Day-1 notes (+ docs placeholder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,40 @@
-# Brain
+# Day-0 Mission
 
-Interdisciplinary symbol–logic engine with entropy-driven P≠NP capsules.
+Turn **harmonic entropy drift** into **machine-checkable P≠NP artifacts** in ≤ 30 days.
+
+> Progressive feedback loop → **Entropy-Collapse Labs** | P≠NP via glyphs & entropy
+
+---
+
+# Day-1: Lean4 Skeleton (Proof Capsule Hook)
+
+This repo ships a minimal Lean4 skeleton so we can pin a green check and
+start threading capsules → proofs.
+
+### Steps
+
+1. Open the Lean4 playground: https://live.lean-lang.org
+2. Paste the contents of `lean4_pnp.lean`.
+3. Press ▶ (Run). You should see a green check.
+4. Take a screenshot and save it to `docs/day1_lean.png`.
+5. Commit the file and screenshot on branch `lean4-proof`.
+
+```bash
+git checkout -b lean4-proof
+git add lean4_pnp.lean docs/day1_lean.png
+git commit -m "Day-1: Lean4 skeleton compiles (green check)"
+git push origin lean4-proof
+```
+
+### Why this skeleton?
+
+- It encodes the **NP-wall** & **no-recovery** gates as named predicates.
+- The theorem returns `True` (trivial) so it **compiles cleanly** without external deps.
+- You can later swap in capsule metadata (hash, ΔΦ window) and strengthen the statement.
+
+See: `lean4_pnp.lean`.
+
+---
 
 ![CI - Python](https://github.com/derekwins88/Brain/actions/workflows/ci-python.yml/badge.svg)
 ![CI - .NET](https://github.com/derekwins88/Brain/actions/workflows/ci-dotnet.yml/badge.svg)

--- a/day1-lean4.patch
+++ b/day1-lean4.patch
@@ -1,0 +1,102 @@
+diff --git a/README.md b/README.md
+index 135e6cd..13a4cb4 100644
+--- a/README.md
++++ b/README.md
+@@ -1,6 +1,38 @@
+-# Brain
++# Day-0 Mission
+ 
+-Interdisciplinary symbol–logic engine with entropy-driven P≠NP capsules.
++Turn **harmonic entropy drift** into **machine-checkable P≠NP artifacts** in ≤ 30 days.
++
++> Progressive feedback loop → **Entropy-Collapse Labs** | P≠NP via glyphs & entropy
++
++---
++
++# Day-1: Lean4 Skeleton (Proof Capsule Hook)
++
++This repo ships a minimal Lean4 skeleton so we can pin a green check and
++start threading capsules → proofs.
++
++### Steps
++1. Open the Lean4 playground: https://live.lean-lang.org
++2. Paste the contents of `lean4_pnp.lean`.
++3. Press ▶ (Run). You should see a green check.
++4. Take a screenshot and save it to `docs/day1_lean.png`.
++5. Commit the file and screenshot on branch `lean4-proof`.
++
++```bash
++git checkout -b lean4-proof
++git add lean4_pnp.lean docs/day1_lean.png
++git commit -m "Day-1: Lean4 skeleton compiles (green check)"
++git push origin lean4-proof
++```
++
++### Why this skeleton?
++- It encodes the **NP-wall** & **no-recovery** gates as named predicates.
++- The theorem returns `True` (trivial) so it **compiles cleanly** without external deps.
++- You can later swap in capsule metadata (hash, ΔΦ window) and strengthen the statement.
++
++See: `lean4_pnp.lean`.
++
++---
+ 
+ ![CI - Python](https://github.com/derekwins88/Brain/actions/workflows/ci-python.yml/badge.svg)
+ ![CI - .NET](https://github.com/derekwins88/Brain/actions/workflows/ci-dotnet.yml/badge.svg)
+diff --git a/docs/.gitkeep b/docs/.gitkeep
+new file mode 100644
+index 0000000..b7a2290
+--- /dev/null
++++ b/docs/.gitkeep
+@@ -0,0 +1 @@
++# placeholder so /docs exists for day1_lean.png
+diff --git a/lean4_pnp.lean b/lean4_pnp.lean
+new file mode 100644
+index 0000000..1154181
+--- /dev/null
++++ b/lean4_pnp.lean
+@@ -0,0 +1,44 @@
++import Mathlib
++
++/-
++  Day-1 Lean4 skeleton for the Entropy Collapse capsule.
++  Goal: compile cleanly (green check) while sketching the NP-wall / no-recovery gates.
++
++  You can later thread in your capsule metadata:
++    • capsule_id:    PROOF⇌<timestamp or hash>
++    • ΔΦ window:     21-point canonical series
++    • claim switch:  npWall ∧ ¬sat ∧ noRecovery → Claim = P≠NP
++-/
++
++namespace EntropyCapsule
++
++/-- NP-wall gate: ΔΦ must exceed 0.09 somewhere in the window. -/
++def NPWall (ΔΦ : ℝ) : Prop := 0.09 < ΔΦ
++
++/-- No-recovery gate: there is no ε < 0.045 such that ΔΦ ≤ ε (i.e., no return below the recovery line). -/
++def NoRecovery (ΔΦ : ℝ) : Prop := ∀ ε : ℝ, ε < 0.045 → ¬ (ΔΦ ≤ ε)
++
++/--
++  Skeleton theorem: encodes the gates as assumptions and concludes `True`.
++  This is intentionally trivial so CI + playground both give a green check now.
++  Replace the `True` goal with a stronger proposition when you thread real capsule data.
++-/
++theorem entropy_wall_skeleton
++    (ΔΦ : ℝ)
++    (h_np : NPWall ΔΦ)
++    (h_nr : NoRecovery ΔΦ)
++    : True := by
++  -- Day-1: we only need a compiled artifact; upgrade this later.
++  exact trivial
++
++/-
++  Notes for Day-2+:
++  * Introduce a `SATShape` predicate tied to the clause CNF (via a bridge or an axiom stub).
++  * Parameterize the statement over a 21-length vector (ΔΦ₀…ΔΦ₂₀) and prove a meta-lemma
++    that when gates hold and the SAT bridge returns UNSAT, we emit the P≠NP claim capsule.
++  * Thread proof capsule hash into a `def CapsuleId : String := "<hash>"` and reference it here.
++-/
++
++end EntropyCapsule
++
++/- EOF -/

--- a/docs/.gitkeep
+++ b/docs/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder so /docs exists for day1_lean.png

--- a/lean4_pnp.lean
+++ b/lean4_pnp.lean
@@ -1,0 +1,44 @@
+import Mathlib
+
+/-
+  Day-1 Lean4 skeleton for the Entropy Collapse capsule.
+  Goal: compile cleanly (green check) while sketching the NP-wall / no-recovery gates.
+
+  You can later thread in your capsule metadata:
+    • capsule_id:    PROOF⇌<timestamp or hash>
+    • ΔΦ window:     21-point canonical series
+    • claim switch:  npWall ∧ ¬sat ∧ noRecovery → Claim = P≠NP
+-/
+
+namespace EntropyCapsule
+
+/-- NP-wall gate: ΔΦ must exceed 0.09 somewhere in the window. -/
+def NPWall (ΔΦ : ℝ) : Prop := 0.09 < ΔΦ
+
+/-- No-recovery gate: there is no ε < 0.045 such that ΔΦ ≤ ε (i.e., no return below the recovery line). -/
+def NoRecovery (ΔΦ : ℝ) : Prop := ∀ ε : ℝ, ε < 0.045 → ¬ (ΔΦ ≤ ε)
+
+/--
+  Skeleton theorem: encodes the gates as assumptions and concludes `True`.
+  This is intentionally trivial so CI + playground both give a green check now.
+  Replace the `True` goal with a stronger proposition when you thread real capsule data.
+-/
+theorem entropy_wall_skeleton
+    (ΔΦ : ℝ)
+    (h_np : NPWall ΔΦ)
+    (h_nr : NoRecovery ΔΦ)
+    : True := by
+  -- Day-1: we only need a compiled artifact; upgrade this later.
+  exact trivial
+
+/-
+  Notes for Day-2+:
+  * Introduce a `SATShape` predicate tied to the clause CNF (via a bridge or an axiom stub).
+  * Parameterize the statement over a 21-length vector (ΔΦ₀…ΔΦ₂₀) and prove a meta-lemma
+    that when gates hold and the SAT bridge returns UNSAT, we emit the P≠NP claim capsule.
+  * Thread proof capsule hash into a `def CapsuleId : String := "<hash>"` and reference it here.
+-/
+
+end EntropyCapsule
+
+/- EOF -/


### PR DESCRIPTION
## Summary
- document Day-0 mission and Day-1 Lean4 skeleton instructions
- add minimal Lean4 proof capsule skeleton with NPWall and NoRecovery gates
- include docs placeholder and patch file for day1 Lean4 setup

## Testing
- `pre-commit run --files README.md lean4_pnp.lean docs/.gitkeep day1-lean4.patch`
- `pytest`
- `cd dotnet && dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c14dcc4b888320bf92cf70722c8cf4