### PR TITLE
ci(lean): auto-sync toolchain with mathlib before action

### DIFF
--- a/.github/scripts/sync_toolchain.sh
+++ b/.github/scripts/sync_toolchain.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PKG_DIR="${1:-lean}"
+
+if [[ ! -d "$PKG_DIR" ]]; then
+  echo "error: package directory '$PKG_DIR' not found" >&2
+  exit 1
+fi
+
+pushd "$PKG_DIR" >/dev/null
+
+if ! command -v lake >/dev/null; then
+  echo "error: 'lake' not on PATH; install elan first." >&2
+  exit 1
+fi
+
+echo "==> lake update (to resolve mathlib and generate manifest)"
+lake update
+
+MATHLIB_TC=".lake/packages/mathlib/lean-toolchain"
+PROJECT_TC="lean-toolchain"
+
+if [[ ! -f "$MATHLIB_TC" ]]; then
+  echo "error: '$MATHLIB_TC' not found after 'lake update'." >&2
+  exit 1
+fi
+
+NEED_COPY=1
+if [[ -f "$PROJECT_TC" ]]; then
+  if cmp -s "$MATHLIB_TC" "$PROJECT_TC"; then
+    NEED_COPY=0
+  fi
+fi
+
+if [[ "$NEED_COPY" -eq 1 ]]; then
+  echo "==> syncing toolchain from mathlib → project"
+  cp "$MATHLIB_TC" "$PROJECT_TC"
+else
+  echo "==> toolchain already in sync"
+fi
+
+popd >/dev/null

--- a/.github/workflows/ci-lean.yml
+++ b/.github/workflows/ci-lean.yml
@@ -5,24 +5,37 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
+    defaults:
+      run:
+        shell: bash
 
-      # Install Lean via elan and prep Mathlib cache where your Lake package lives
-      - name: Setup Lean
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install elan (bootstrap)
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | bash -s -- -y
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+      - name: Sync toolchain with Mathlib (pre-action)
+        run: |
+          bash .github/scripts/sync_toolchain.sh lean
+        env:
+          LEAN_PACKAGE_DIR: lean
+
+      - name: Setup Lean (official action)
         uses: leanprover/lean-action@v1
         with:
-          lake-package-directory: lean      # <-- valid input
+          lake-package-directory: lean
           auto-config: true
           use-mathlib-cache: true
           reinstall-transient-toolchain: true
 
-      # Create lake-manifest.json and fetch deps
       - name: lake update
         run: lake update
         working-directory: lean
 
-      # Build the package
       - name: lake build
         run: lake build
         working-directory: lean


### PR DESCRIPTION
## Summary
- add sync_toolchain.sh to mirror Mathlib's toolchain into the project
- update Lean CI workflow to bootstrap elan, sync toolchain, then run lake update/build

## Testing
- `pre-commit run --files .github/workflows/ci-lean.yml .github/scripts/sync_toolchain.sh`
- `bash .github/scripts/sync_toolchain.sh lean` *(fails: 'lake' not on PATH; install elan first.)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c82cc7048320b45926da21bc709f