### PR TITLE
ci(lean): sync toolchain with mathlib

### DIFF
--- a/.github/scripts/sync_toolchain.sh
+++ b/.github/scripts/sync_toolchain.sh
@@ -1,43 +1,52 @@
 #!/usr/bin/env bash
+# Sync project's lean-toolchain with Mathlib's pinned toolchain (idempotent).
+# - Uses existing mathlib toolchain if available.
+# - If missing and 'lake' exists, runs 'lake update' to materialize it.
+# - If 'lake' is missing and toolchain isn't present, exits 0 (no-op).
+
 set -euo pipefail
 
 PKG_DIR="${1:-lean}"
+MATHLIB_TC_REL=".lake/packages/mathlib/lean-toolchain"
+PROJECT_TC_REL="lean-toolchain"
 
 if [[ ! -d "$PKG_DIR" ]]; then
-  echo "error: package directory '$PKG_DIR' not found" >&2
-  exit 1
+  echo "sync_toolchain: package dir '$PKG_DIR' not found; nothing to do."
+  exit 0
 fi
 
 pushd "$PKG_DIR" >/dev/null
 
-if ! command -v lake >/dev/null; then
-  echo "error: 'lake' not on PATH; install elan first." >&2
-  exit 1
+have_lake=0
+if command -v lake >/dev/null 2>&1; then
+  have_lake=1
 fi
 
-echo "==> lake update (to resolve mathlib and generate manifest)"
-lake update
-
-MATHLIB_TC=".lake/packages/mathlib/lean-toolchain"
-PROJECT_TC="lean-toolchain"
-
-if [[ ! -f "$MATHLIB_TC" ]]; then
-  echo "error: '$MATHLIB_TC' not found after 'lake update'." >&2
-  exit 1
-fi
-
-NEED_COPY=1
-if [[ -f "$PROJECT_TC" ]]; then
-  if cmp -s "$MATHLIB_TC" "$PROJECT_TC"; then
-    NEED_COPY=0
+# If mathlib's toolchain isn't there yet, try to create it via 'lake update' when possible.
+if [[ ! -f "$MATHLIB_TC_REL" ]]; then
+  if [[ "$have_lake" -eq 1 ]]; then
+    echo "sync_toolchain: '$MATHLIB_TC_REL' missing; running 'lake update' to materialize it..."
+    lake update
+  else
+    echo "sync_toolchain: '$MATHLIB_TC_REL' missing and 'lake' not found; skip (will be retried later)."
+    popd >/dev/null
+    exit 0
   fi
 fi
 
-if [[ "$NEED_COPY" -eq 1 ]]; then
-  echo "==> syncing toolchain from mathlib → project"
-  cp "$MATHLIB_TC" "$PROJECT_TC"
+# If still missing after lake update, nothing to sync.
+if [[ ! -f "$MATHLIB_TC_REL" ]]; then
+  echo "sync_toolchain: mathlib toolchain still not found after 'lake update'; skipping."
+  popd >/dev/null
+  exit 0
+fi
+
+# Sync only when different (keeps git diffs clean).
+if [[ -f "$PROJECT_TC_REL" ]] && cmp -s "$MATHLIB_TC_REL" "$PROJECT_TC_REL"; then
+  echo "sync_toolchain: toolchain already in sync ✅"
 else
-  echo "==> toolchain already in sync"
+  echo "sync_toolchain: syncing mathlib → project toolchain"
+  cp "$MATHLIB_TC_REL" "$PROJECT_TC_REL"
 fi
 
 popd >/dev/null

--- a/.github/workflows/ci-lean.yml
+++ b/.github/workflows/ci-lean.yml
@@ -1,36 +1,33 @@
+---
 name: CI - Lean4
-on: [push, pull_request]
+"on": [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        shell: bash
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install elan (bootstrap)
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | bash -s -- -y
-          echo "$HOME/.elan/bin" >> $GITHUB_PATH
-
-      - name: Sync toolchain with Mathlib (pre-action)
-        run: |
-          bash .github/scripts/sync_toolchain.sh lean
-        env:
-          LEAN_PACKAGE_DIR: lean
-
-      - name: Setup Lean (official action)
+      - name: Setup Lean
         uses: leanprover/lean-action@v1
         with:
           lake-package-directory: lean
           auto-config: true
           use-mathlib-cache: true
           reinstall-transient-toolchain: true
+
+      - name: Sync toolchain with Mathlib
+        run: |
+          bash .github/scripts/sync_toolchain.sh lean
+
+      - name: Verify toolchain in sync
+        run: |
+          diff lean/.lake/packages/mathlib/lean-toolchain \
+            lean/lean-toolchain || (
+            echo "Toolchain mismatch with Mathlib!" >&2; exit 1
+          )
 
       - name: lake update
         run: lake update


### PR DESCRIPTION
## Summary
- add script to sync project toolchain with mathlib's pinned toolchain
- verify mathlib and project toolchains match in Lean CI

## Testing
- `bash -n .github/scripts/sync_toolchain.sh`
- `yamllint .github/workflows/ci-lean.yml`
- `pre-commit run --files .github/scripts/sync_toolchain.sh .github/workflows/ci-lean.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c1cbc090ac8320b10f177a07668075