### PR TITLE
ci(lean): curl-first toolchain sync; lake fallback; run action with synced toolchain

### DIFF
--- a/.github/workflows/ci-lean.yml
+++ b/.github/workflows/ci-lean.yml
@@ -9,17 +9,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Stage A: bootstrap elan to get 'lake' so we can sync toolchain
-      - name: Install elan (bootstrap)
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | bash -s -- -y
-          echo "$HOME/.elan/bin" >> $GITHUB_PATH
-
-      # Stage A2: sync project toolchain to Mathlib's (materializes via lake update if needed)
+      # Pre-sync the project's toolchain to Mathlib's (curl first; lake fallback)
       - name: Sync toolchain with Mathlib (pre-action)
         run: bash .github/scripts/sync_toolchain.sh lean
 
-      # Stage B: official Lean action now sees correct toolchain and restores Mathlib cache
+      # Now install Lean using the synced toolchain and restore Mathlib cache
       - name: Setup Lean (official action)
         uses: leanprover/lean-action@v1
         with:
@@ -28,7 +22,7 @@ jobs:
           use-mathlib-cache: true
           reinstall-transient-toolchain: true
 
-      # Optional guard: fail if someone changed lean/lean-toolchain after sync
+      # Guard: ensure the committed file matches Mathlib’s pin
       - name: Verify toolchain in sync
         run: |
           diff lean/.lake/packages/mathlib/lean-toolchain lean/lean-toolchain || (


### PR DESCRIPTION
## Summary
- sync project lean-toolchain with Mathlib using curl-first script, lake fallback
- update Lean CI workflow to run sync script before lean-action

## Testing
- `python3 -m pre_commit run --files .github/scripts/sync_toolchain.sh .github/workflows/ci-lean.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c1d27be24483209d4cb6e20df98306