### PR TITLE
ci(capsules): add presence check + badge in README

### DIFF
--- a/.github/workflows/ci-capsules.yml
+++ b/.github/workflows/ci-capsules.yml
@@ -1,0 +1,18 @@
+name: CI - Capsules
+on: [push, pull_request]
+
+jobs:
+  check-capsules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for capsule files
+        run: |
+          if [ -z "$(ls capsules/*.json 2>/dev/null)" ]; then
+            echo "❌ No capsules found in /capsules"
+            exit 1
+          else
+            echo "✅ Capsules detected:"
+            ls capsules/*.json
+          fi

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![CI - .NET](https://github.com/derekwins88/Brain/actions/workflows/ci-dotnet.yml/badge.svg)](https://github.com/derekwins88/Brain/actions/workflows/ci-dotnet.yml)
 [![CI - Lean4](https://github.com/derekwins88/Brain/actions/workflows/ci-lean.yml/badge.svg)](https://github.com/derekwins88/Brain/actions/workflows/ci-lean.yml)
 [![Proof v1.1 (smoke)](https://github.com/derekwins88/Brain/actions/workflows/ci-proof.yml/badge.svg)](https://github.com/derekwins88/Brain/actions/workflows/ci-proof.yml)
+![Capsules](https://github.com/derekwins88/Brain/actions/workflows/ci-capsules.yml/badge.svg)
 
 **Status:** Day-1 green ✅ — Python, .NET, Lean4 build pass; Proof v1.1 pipeline smoke passes (PDF check is permissive until full translator is wired).
 
@@ -13,33 +14,20 @@ Turn **harmonic entropy drift** into **machine-checkable P≠NP artifacts** in �
 
 ---
 
-# Day-1: Lean4 Skeleton (Proof Capsule Hook)
+## Day-1: Lean4 Proof Scaffold ✅
 
-This repo ships a minimal Lean4 skeleton so we can pin a green check and
-start threading capsules → proofs.
+![CI - Python](https://github.com/derekwins88/Brain/actions/workflows/ci-python.yml/badge.svg)
+![CI - .NET](https://github.com/derekwins88/Brain/actions/workflows/ci-dotnet.yml/badge.svg)
+![CI - Lean4](https://github.com/derekwins88/Brain/actions/workflows/ci-lean.yml/badge.svg)
+![CI - Proof](https://github.com/derekwins88/Brain/actions/workflows/ci-proof.yml/badge.svg)
+![CI - Capsules](https://github.com/derekwins88/Brain/actions/workflows/ci-capsules.yml/badge.svg)
 
-### Steps
+- Encodes the NP-wall & no-recovery gates as predicates.
+- Returns `True` (via `sorry`) so it compiles cleanly.
+- Capsule metadata strengthens the statement.
 
-1. Open the Lean4 playground: https://live.lean-lang.org
-2. Paste the contents of `lean4_pnp.lean`.
-3. Press ▶ (Run). You should see a green check.
-4. Take a screenshot and save it to `docs/day1_lean.png`.
-5. Commit the file and screenshot on branch `lean4-proof`.
-
-```bash
-git checkout -b lean4-proof
-git add lean4_pnp.lean docs/day1_lean.png
-git commit -m "Day-1: Lean4 skeleton compiles (green check)"
-git push origin lean4-proof
-```
-
-### Why this skeleton?
-
-- It encodes the **NP-wall** & **no-recovery** gates as named predicates.
-- The theorem returns `True` (trivial) so it **compiles cleanly** without external deps.
-- You can later swap in capsule metadata (hash, ΔΦ window) and strengthen the statement.
-
-See: `lean4_pnp.lean`.
+See: [lean4_pnp.lean](./lean4_pnp.lean)  
+Capsule: [IMM⇌MATH⇌ALSTEIN01](./capsules/IMM_MATH_ALSTEIN01.json)
 
 ---
 
@@ -61,4 +49,5 @@ We follow a **3-rule contributor guide**:
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## CI
+
 ![CI - Lean4](https://img.shields.io/badge/CI--Lean4-passing-success)


### PR DESCRIPTION
## Summary
- add workflow to ensure at least one capsule JSON exists
- document capsules status badge and Lean4 proof scaffold example

## Testing
- `pre-commit run --files README.md .github/workflows/ci-capsules.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'brain')*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f089c0b483208d4848619d07e60e