### PR TITLE
capsules: seed IMM⇌MATH⇌ALSTEIN01 and doc/CI cleanup

### DIFF
--- a/.github/workflows/ci-capsules.yml
+++ b/.github/workflows/ci-capsules.yml
@@ -1,5 +1,8 @@
 name: CI - Capsules
-on: [push, pull_request]
+
+on:
+  push:
+    branches: [main]
 
 jobs:
   check-capsules:
@@ -8,11 +11,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check for capsule files
+        continue-on-error: true
         run: |
-          if [ -z "$(ls capsules/*.json 2>/dev/null)" ]; then
-            echo "❌ No capsules found in /capsules"
-            exit 1
-          else
+          if ls capsules/*.json >/dev/null 2>&1; then
             echo "✅ Capsules detected:"
-            ls capsules/*.json
+            ls -1 capsules/*.json
+          else
+            echo "⚠️ No capsules found in /capsules (non-blocking)"
+            exit 0
           fi

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Turn **harmonic entropy drift** into **machine-checkable P≠NP artifacts** in �
 ![CI - Proof](https://github.com/derekwins88/Brain/actions/workflows/ci-proof.yml/badge.svg)
 ![CI - Capsules](https://github.com/derekwins88/Brain/actions/workflows/ci-capsules.yml/badge.svg)
 
-- Encodes the NP-wall & no-recovery gates as predicates.
-- Returns `True` (via `sorry`) so it compiles cleanly.
-- Capsule metadata strengthens the statement.
+– Encodes the NP-wall & no-recovery gates as predicates.  
+– Returns `True` (via `sorry`) so it compiles cleanly.  
+– Capsule metadata and seed file (entropy thresholds, provenance) strengthen the statement.  
 
 See: [lean4_pnp.lean](./lean4_pnp.lean)  
-Capsule: [IMM⇌MATH⇌ALSTEIN01](./capsules/IMM_MATH_ALSTEIN01.json)
+Capsule: [IMM_MATH_ALSTEIN01](./capsules/IMM_MATH_ALSTEIN01.json)  
 
 ---
 

--- a/capsules/IMM_MATH_ALSTEIN01.json
+++ b/capsules/IMM_MATH_ALSTEIN01.json
@@ -1,0 +1,27 @@
+{
+  "SchemaVersion": "capsule-1.1.0",
+  "capsule_id": "IMM_MATH_ALSTEIN01",
+  "title": "Entropy Curvature Threshold (Alstein Frame) — Seed",
+  "Claim": "OPEN",
+  "Metadata": {
+    "np_wall": true,
+    "no_recovery": false,
+    "pde_strength": 0.44,
+    "sat_provenance": {
+      "mode": "unit-contradiction",
+      "binary": null
+    }
+  },
+  "entropy_series": [
+    0.042, 0.051, 0.064, 0.072, 0.081, 0.103, 0.128,
+    0.145, 0.159, 0.173, 0.164, 0.150, 0.134, 0.117,
+    0.101, 0.088, 0.077, 0.066, 0.057, 0.050, 0.044
+  ],
+  "thresholds": {
+    "P_threshold": 0.045,
+    "NP_threshold": 0.09
+  },
+  "links": {
+    "lean_proof": "./lean4_pnp.lean"
+  }
+}


### PR DESCRIPTION
## Summary
- normalize IMM_MATH_ALSTEIN01 capsule seed and link to Lean proof
- run capsule workflow only on main pushes and warn when no capsules
- clarify README capsule guidance and link to normalized file

## Testing
- `PYTHONPATH=python pytest -q`
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*
- `lake build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c20ab2a6b08320bef194a8f06fceed