### PR TITLE
day2: add sieve sieve and capsule generator

### DIFF
--- a/.github/workflows/ci-data.yml
+++ b/.github/workflows/ci-data.yml
@@ -7,21 +7,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run quick CPU sieve (small)
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
         run: |
-          python --version || sudo apt-get update && sudo apt-get install -y python3 python3-pip
-          python3 - <<'PY'
-import os, subprocess, sys
-# run small sample to produce CSV/meta; force CPU run
-env = os.environ.copy()
-env["N_TRACES"] = "20000"
-env["TRACE_LEN"] = "48"
-env["CSV_PATH"]  = "data/entropy_sieve_ci.csv"
-env["META_PATH"] = "data/entropy_sieve_ci.json"
-env["SPIKE_PROB"] = "0.035"
-rc = subprocess.call([sys.executable, "sieve.py"], env=env)
-sys.exit(rc)
-PY
+          python -m pip install --upgrade pip
+          pip install numpy  # CuPy optional; we fall back to CPU
+
+      - name: Run quick CPU sieve (small)
+        env:
+          N_TRACES: "20000"
+          TRACE_LEN: "48"
+          CSV_PATH: "data/entropy_sieve_ci.csv"
+          META_PATH: "data/entropy_sieve_ci.json"
+          SPIKE_PROB: "0.035"
+        run: |
+          python sieve.py
 
       - name: Verify CSV exists & has rows
         run: |
@@ -31,3 +35,15 @@ PY
             echo "CSV too small ($lines lines)"; exit 1
           fi
           echo "✅ CSV ok ($lines lines)"
+
+      - name: Generate Day-2 capsule from meta
+        run: |
+          python tools/capsule_from_meta.py \
+            --meta data/entropy_sieve_ci.json \
+            --out  capsules/SIEVE_DAY2.json
+
+      - name: Upload capsule artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SIEVE_DAY2-capsule
+          path: capsules/SIEVE_DAY2.json

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ python3 sieve.py
 # Bigger run (edit envs)
 N_TRACES=10000000 TRACE_LEN=64 CSV_PATH=data/entropy_sieve_10m.csv python3 sieve.py
 
+```
+
+Day-2 capsule: [SIEVE_DAY2](./capsules/SIEVE_DAY2.json)
+
 Colab
 Open: https://colab.research.google.com/github/derekwins88/Brain/blob/main/sieve.py
 Run all → commit the CSV from /content/ to data/.

--- a/capsules/SIEVE_DAY2.json
+++ b/capsules/SIEVE_DAY2.json
@@ -1,0 +1,32 @@
+{
+  "SchemaVersion": "capsule-1.1.0",
+  "capsule_id": "SIEVE_DAY2",
+  "title": "Day-2 GPU Entropy Sieve \u2014 Summary",
+  "Claim": "OPEN",
+  "Metadata": {
+    "np_wall": true,
+    "no_recovery": false,
+    "sat_provenance": {
+      "mode": "sieve",
+      "binary": null
+    }
+  },
+  "summary": {
+    "np_hits_pct": 3.44,
+    "np_hits": 688,
+    "n_traces": 20000,
+    "backend": "cpu",
+    "trace_len": 48,
+    "elapsed_sec": 0.174
+  },
+  "thresholds": {
+    "P_threshold": 0.045,
+    "NP_threshold": 0.09
+  },
+  "provenance": {
+    "meta_path": "data/entropy_sieve_ci.json",
+    "csv_path": "data/entropy_sieve_ci.csv",
+    "commit": null,
+    "generated_at_utc": "2025-09-11T05:23:41Z"
+  }
+}

--- a/data/.gitkeep
+++ b/data/.gitkeep
@@ -1,1 +1,1 @@
-# placeholder so /data exists before CSVs are committed
+# placeholder

--- a/sieve.py
+++ b/sieve.py
@@ -1,21 +1,18 @@
 #!/usr/bin/env python3
 """
 Day-2: GPU Entropy Sieve
-- Generates/streams entropy traces and flags irreversible spikes (ΔΦ > NP_threshold)
+- Generates/streams entropy traces and flags irreversible spikes (ΔΦ > NP_THRESHOLD)
 - Uses CuPy (GPU) if available; falls back to NumPy (CPU)
-- Writes summary CSV(s) under ./data/
+- Writes summary CSV + meta JSON under ./data/
 """
-
 from __future__ import annotations
 import os, sys, time, math, csv, json, random
 from typing import Tuple
 
-# --- Try GPU (CuPy), else CPU (NumPy) ---------------------------------------
-xp = None
+# Prefer GPU via CuPy; fall back to NumPy
 backend = "cpu"
 try:
     import cupy as cp  # type: ignore
-    # Ensure at least a device is visible
     _ = cp.cuda.runtime.getDeviceCount()
     xp = cp
     backend = "cuda"
@@ -24,21 +21,19 @@ except Exception:
     xp = np
     backend = "cpu"
 
-# --- Config -----------------------------------------------------------------
-NP_THRESHOLD = float(os.getenv("NP_THRESHOLD", "0.09"))    # irreversible ΔΦ
-P_THRESHOLD  = float(os.getenv("P_THRESHOLD",  "0.045"))   # soft/linear bound
-N_TRACES     = int(os.getenv("N_TRACES",      "1000000"))  # 1e6 default for CI; bump to 1e8 on Colab
-TRACE_LEN    = int(os.getenv("TRACE_LEN",     "64"))       # samples per trace
+# Config via env (small defaults for CI)
+NP_THRESHOLD = float(os.getenv("NP_THRESHOLD", "0.09"))
+P_THRESHOLD  = float(os.getenv("P_THRESHOLD",  "0.045"))
+N_TRACES     = int(os.getenv("N_TRACES",      "20000"))
+TRACE_LEN    = int(os.getenv("TRACE_LEN",     "48"))
 SEED         = int(os.getenv("SEED",          "42"))
-CSV_PATH     = os.getenv("CSV_PATH", "data/entropy_sieve_sample.csv")
-META_PATH    = os.getenv("META_PATH", "data/entropy_sieve_meta.json")
-BATCH        = int(os.getenv("BATCH",         "100000"))   # process in chunks
+CSV_PATH     = os.getenv("CSV_PATH", "data/entropy_sieve_ci.csv")
+META_PATH    = os.getenv("META_PATH", "data/entropy_sieve_ci.json")
+BATCH        = int(os.getenv("BATCH",         "100000"))
 
-# Synthetic generator controls (kept simple for Day-2 demo)
-SPIKE_PROB   = float(os.getenv("SPIKE_PROB", "0.035"))     # ~3.5% with spikes > 0.09
+SPIKE_PROB   = float(os.getenv("SPIKE_PROB", "0.035"))
 NOISE_SIGMA  = float(os.getenv("NOISE_SIGMA","0.02"))
 
-# --- Helpers ----------------------------------------------------------------
 def rng_rand(shape, seed=None):
     if backend == "cuda":
         rs = xp.random.RandomState(SEED if seed is None else seed)
@@ -56,61 +51,39 @@ def rng_normal(shape, sigma, seed=None):
         return rs.normal(loc=0.0, scale=sigma, size=shape)
 
 def gen_traces(n: int, length: int) -> xp.ndarray:
-    """
-    Generate entropy drift traces with occasional irreversible spikes.
-    Baseline noise around ~0.03–0.06; spikes push ΔΦ > NP_THRESHOLD.
-    """
-    base = 0.03 + 0.03 * rng_rand((n, 1))                     # [0.03, 0.06)
-    noise = rng_normal((n, length), NOISE_SIGMA)              # zero-mean
+    base = 0.03 + 0.03 * rng_rand((n, 1))          # [0.03, 0.06)
+    noise = rng_normal((n, length), NOISE_SIGMA)
     traces = xp.clip(base + noise.cumsum(axis=1)/length, 0, None)
 
-    # Inject spikes
+    # Inject spike near last third
     spikes = (rng_rand((n, 1)) < SPIKE_PROB).astype(traces.dtype)
-    spike_height = NP_THRESHOLD + 0.02 + 0.05 * rng_rand((n, 1))  # > NP_THRESHOLD
-    # Put spike near last third of the trace
+    spike_height = NP_THRESHOLD + 0.02 + 0.05 * rng_rand((n, 1))
     idx = xp.full((n,), int(0.66 * length))
-    if backend == "cuda":
-        rows = xp.arange(n, dtype=xp.int32)
-        traces[rows, idx] += (spikes[:, 0] * spike_height[:, 0])
-    else:
-        rows = xp.arange(n)
-        traces[rows, idx] += (spikes[:, 0] * spike_height[:, 0])
+    rows = xp.arange(n, dtype=xp.int32) if backend == "cuda" else xp.arange(n)
+    traces[rows, idx] += (spikes[:, 0] * spike_height[:, 0])
     return traces
-
-def stats_from_traces(traces: xp.ndarray) -> Tuple[int, int, float]:
-    n = traces.shape[0]
-    maxvals = traces.max(axis=1)
-    np_hits = (maxvals > NP_THRESHOLD)
-    count_np = int(xp.asnumpy(np_hits).sum()) if backend == "cuda" else int(np_hits.sum())
-    pct = (100.0 * count_np / n) if n else 0.0
-    return n, count_np, pct
 
 def ensure_dir(path: str):
     d = os.path.dirname(path)
     if d and not os.path.exists(d):
         os.makedirs(d, exist_ok=True)
 
-# --- Main -------------------------------------------------------------------
 def main():
     t0 = time.time()
     random.seed(SEED)
-
-    ensure_dir(CSV_PATH)
-    ensure_dir(META_PATH)
+    ensure_dir(CSV_PATH); ensure_dir(META_PATH)
 
     total = 0
     total_np = 0
     batches = math.ceil(N_TRACES / BATCH)
 
-    # Write CSV header
     with open(CSV_PATH, "w", newline="") as fcsv:
         w = csv.writer(fcsv)
         w.writerow(["trace_id", "max_delta_phi", "np_hit", "length", "backend"])
 
-        for b in range(batches):
+        for _ in range(batches):
             size = min(BATCH, N_TRACES - total)
             traces = gen_traces(size, TRACE_LEN)
-            # Compute metrics
             maxvals = traces.max(axis=1)
             np_hits = (maxvals > NP_THRESHOLD)
 
@@ -121,22 +94,17 @@ def main():
                 maxvals_np = maxvals
                 np_hits_np = np_hits.astype(int)
 
-            # Emit CSV rows (only summary per trace for Day-2)
             for i in range(size):
                 w.writerow([total + i, float(maxvals_np[i]), int(np_hits_np[i]), TRACE_LEN, backend])
 
-            # update totals
             total += size
             total_np += int(np_hits_np.sum())
 
-            # free GPU memory between batches
             if backend == "cuda":
                 del traces, maxvals, np_hits
                 xp.get_default_memory_pool().free_all_blocks()
 
-    pct = 100.0 * total_np / total if total else 0.0
-
-    # Write meta JSON
+    pct = (100.0 * total_np / total) if total else 0.0
     meta = {
         "SchemaVersion": "sieve-1.0.0",
         "backend": backend,

--- a/tools/capsule_from_meta.py
+++ b/tools/capsule_from_meta.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Generate a capsule JSON from Day-2 sieve meta.
+
+Usage:
+  python tools/capsule_from_meta.py \
+    --meta data/entropy_sieve_ci.json \
+    --out  capsules/SIEVE_DAY2.json
+"""
+from __future__ import annotations
+import argparse, json, os, sys, time
+from typing import Any, Dict
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--meta", required=True, help="Path to sieve meta JSON")
+    ap.add_argument("--out",  required=True, help="Output capsule JSON path")
+    ap.add_argument("--capsule-id", default="SIEVE_DAY2", help="Capsule ID")
+    ap.add_argument("--title", default="Day-2 GPU Entropy Sieve — Summary", help="Capsule title")
+    ap.add_argument("--p-threshold", type=float, default=0.045)
+    ap.add_argument("--np-threshold", type=float, default=0.09)
+    args = ap.parse_args()
+
+    with open(args.meta) as f:
+        meta = json.load(f)
+
+    pct = float(meta.get("np_hits_pct", 0.0))
+    np_hits = int(meta.get("np_hits", 0))
+    n_traces = int(meta.get("n_traces", 0))
+
+    capsule: Dict[str, Any] = {
+        "SchemaVersion": "capsule-1.1.0",
+        "capsule_id": args.capsule_id,
+        "title": args.title,
+        "Claim": "OPEN",
+        "Metadata": {
+            # true iff any irreversible spikes were found in this sieve run
+            "np_wall": np_hits > 0,
+            # Day-2 doesn’t prove no-recovery; we’ll refine later
+            "no_recovery": False,
+            "sat_provenance": { "mode": "sieve", "binary": None },
+        },
+        "summary": {
+            "np_hits_pct": round(pct, 4),
+            "np_hits": np_hits,
+            "n_traces": n_traces,
+            "backend": meta.get("backend"),
+            "trace_len": meta.get("trace_len"),
+            "elapsed_sec": meta.get("elapsed_sec"),
+        },
+        "thresholds": {
+            "P_threshold": args.p_threshold,
+            "NP_threshold": args.np_threshold
+        },
+        "provenance": {
+            "meta_path": args.meta,
+            "csv_path": meta.get("csv_path"),
+            "commit": os.getenv("GITHUB_SHA", None),
+            "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        },
+    }
+
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    with open(args.out, "w") as g:
+        json.dump(capsule, g, indent=2)
+    print(f"[capsule] wrote {args.out}")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add GPU/CPU entropy sieve script with env-driven thresholds
- harden data workflow to set up Python, install NumPy and generate capsule artifact
- document Day-2 capsule and add capsule_from_meta utility

## Testing
- `PYTHONPATH=python pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c25c78aaec8320890ace51ecaf73bd