### PR TITLE
Add CONTRIBUTING guide and README re-render snippet (Day-3 polish)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,93 @@
 # Contributing Guide
 
-We keep this project healthy through three simple rules:
-
-1. **All tests must pass**
-   - Run Python tests with `pytest -q`
-   - Run .NET tests with `dotnet test`
-
-2. **Docs must be touched**
-   - Update `README.md`, `CONTRIBUTING.md`, or inline comments where needed.
-
-3. **Each PR must include a story sentence**
-   - One line that connects your contribution to the larger narrative.
-   - Example: _“This refactor stabilizes the entropy gate — the glyph no longer drifts without cause.”_
+Thanks for your interest in contributing!  
+This project evolves in **Day milestones** (Day-1, Day-2, Day-3, …).  
+Here’s how you can work with the current foundation.
 
 ---
 
-Thanks for helping build the Brain ecosystem with both rigor and story.
+## Workflow overview
+
+- **Day-1:** Lean4 skeleton + proof-of-concept check.
+- **Day-2:** Entropy sieve (`sieve.py` + `sieve.ipynb`) + CI capsule stream.
+- **Day-3:** Infographic auto-render pipeline (JSON → PNG → Gallery).
+
+---
+
+## Running the sieve (Day-2)
+
+Small local run (CPU is fine):
+
+```bash
+python3 sieve.py
+```
+
+Larger run (edit envs as needed):
+
+```bash
+N_TRACES=1000000 TRACE_LEN=64 CSV_PATH=data/entropy_sieve.csv python3 sieve.py
+```
+
+Capsule JSON is written under capsules/.
+
+⸻
+
+## Re-rendering the infographic (Day-3)
+
+There are two ways to refresh docs/day3_infographic.png:
+
+### Local execution
+
+```bash
+python -m nbconvert --to notebook --execute \
+  notebooks/render_infographic.ipynb \
+  --output /tmp/render_output.ipynb
+```
+
+This updates docs/day3_infographic.png and (optionally) docs/day3_infographic.json.
+
+### GitHub Actions (auto)
+
+- Push any change to main (for example, capsule JSON update).
+- Workflow Auto-render infographic runs automatically:
+  - Executes the notebook.
+  - Validates JSON against schema.
+  - Uploads PNG as artifact and/or commits it back to docs/.
+
+⸻
+
+## Pre-commit
+
+This repo uses pre-commit to:
+
+- Format Python with Black.
+- Keep sieve.py and sieve.ipynb in sync via Jupytext.
+
+Install hooks locally:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Then commits will run the hooks automatically.
+
+⸻
+
+## Submitting changes
+
+1. Fork and branch from main.
+2. Run tests:
+
+```bash
+PYTHONPATH=. pytest -q
+```
+
+3. Push and open a PR.
+
+⸻
+
+## Questions?
+
+Open an issue or check the Gallery in README to see the project evolution.
+

--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Notebook: github.com/derekwins88/Brain/blob/main/sieve.py
   Metadata → **[docs/day3_infographic.json](docs/day3_infographic.json)**  
   Open in Colab → **[render_infographic.ipynb](https://colab.research.google.com/github/derekwins88/Brain/blob/main/notebooks/render_infographic.ipynb)**
 
+_Re-render locally:_
+
+```bash
+python -m nbconvert --to notebook --execute \
+  notebooks/render_infographic.ipynb \
+  --output /tmp/render_output.ipynb
+```
+
+Or trigger the Auto-render infographic GitHub Action to refresh docs/day3_infographic.png automatically.
+
 > Tip: in Colab, **Runtime → Run all**. The notebook writes `docs/day3_infographic.png` back into the repo tree for an easy PR.
 
 ---


### PR DESCRIPTION
## Summary
- add comprehensive `CONTRIBUTING.md` with Day-1→Day-3 workflow, sieve/infographic instructions, and pre-commit setup
- document a quick Day-3 infographic re-render command in the README

## Testing
- `PYTHONPATH=python pytest -q`
- `pre-commit run --files README.md CONTRIBUTING.md` *(fails: asked for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68c48fd159d08320ba56918d96e48614