### PR TITLE
docs: add benchmark workflow and gallery badges

### DIFF
--- a/.github/workflows/ci-bench.yml
+++ b/.github/workflows/ci-bench.yml
@@ -1,0 +1,52 @@
+name: CI - Bench
+on: [push, pull_request]
+permissions:
+  contents: write   # only needed if you commit PNG/HTML back to main
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { persist-credentials: true }
+
+      - uses: actions/setup-python@v4
+        with: { python-version: '3.11' }
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy cupy-cuda11x || pip install numpy  # tolerate no-GPU runners
+          pip install matplotlib pillow
+
+      - name: Run bench (small)
+        run: |
+          mkdir -p out gallery docs
+          python bench.py --traces 100000 --mode auto -o out/bench_ci_auto.csv
+
+      - name: Plot chart
+        run: python plot_bench.py out/bench_ci_auto.csv -o gallery/day4_bench.png
+
+      - name: Build gallery HTML
+        run: python gallery.py --capsules out/*.json --theme dark --out docs/gallery.html || echo "No capsules yet; built page without list."
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: day4-gallery
+          path: |
+            gallery/day4_bench.png
+            docs/gallery.html
+
+      # Optional: commit updates back to main if files changed
+      - name: Commit gallery (optional)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add gallery/day4_bench.png docs/gallery.html
+          if ! git diff --staged --quiet; then
+            git commit -m "ci(bench): refresh Day-4 chart + gallery"
+            git push
+          else
+            echo "No changes to commit."
+          fi

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-[![CI - Python](https://github.com/derekwins88/Brain/actions/workflows/ci-python.yml/badge.svg)](https://github.com/derekwins88/Brain/actions/workflows/ci-python.yml)
-[![CI - .NET](https://github.com/derekwins88/Brain/actions/workflows/ci-dotnet.yml/badge.svg)](https://github.com/derekwins88/Brain/actions/workflows/ci-dotnet.yml)
-[![CI - Lean4](https://github.com/derekwins88/Brain/actions/workflows/ci-lean.yml/badge.svg)](https://github.com/derekwins88/Brain/actions/workflows/ci-lean.yml)
-[![Proof v1.1 (smoke)](https://github.com/derekwins88/Brain/actions/workflows/ci-proof.yml/badge.svg)](https://github.com/derekwins88/Brain/actions/workflows/ci-proof.yml)
-![Capsules](https://github.com/derekwins88/Brain/actions/workflows/ci-capsules.yml/badge.svg)
+<!-- Badges: add near your other CI badges -->
+![CI – Python](https://github.com/derekwins88/Brain/actions/workflows/ci-python.yml/badge.svg)
+![CI – .NET](https://github.com/derekwins88/Brain/actions/workflows/ci-dotnet.yml/badge.svg)
+![CI – Lean4](https://github.com/derekwins88/Brain/actions/workflows/ci-lean.yml/badge.svg)
+![CI – Proof v1.1 (smoke)](https://github.com/derekwins88/Brain/actions/workflows/ci-proof.yml/badge.svg)
+![CI – Capsules](https://github.com/derekwins88/Brain/actions/workflows/ci-capsules.yml/badge.svg)
+![CI – Data](https://github.com/derekwins88/Brain/actions/workflows/ci-data.yml/badge.svg)
+![CI – Infographic](https://github.com/derekwins88/Brain/actions/workflows/auto_render_infographic.yml/badge.svg)
+![CI – Bench](https://github.com/derekwins88/Brain/actions/workflows/ci-bench.yml/badge.svg)
 
 **Status:** Day-1 green ✅ — Python, .NET, Lean4 build pass; Proof v1.1 pipeline smoke passes (PDF check is permissive until full translator is wired).
 
@@ -67,33 +71,31 @@ Notebook: github.com/derekwins88/Brain/blob/main/sieve.py
 #PvsNP #Lean4 #EntropyCollapse
 ```
 
+## Day-4: Benchmark & Gallery
 
-## Gallery
+- **Throughput bench (GPU↔CPU)**  
+  Runs a micro-benchmark on CuPy when available (falls back to NumPy), then plots ΔΦ trace throughput.  
+  **Chart:** [gallery/day4_bench.png](./gallery/day4_bench.png)
 
-- **Lean4 Green Check (Day-1)**  
-  ![lean4 green](docs/day1_lean.png)
+- **Capsule Gallery (auto-built)**  
+  Lists recent capsules (latest JSONs) and embeds the Day-4 chart.  
+  **Open:** [docs/gallery.html](./docs/gallery.html)
 
-- **Day-2 Sieve Capsule**  
-  See: [`SIEVE_DAY2`](capsules/SIEVE_DAY2.json)
-
-- **Day-3 Infographic (auto-rendered)**  
-  Output → **[docs/day3_infographic.png](docs/day3_infographic.png)**  
-  Metadata → **[docs/day3_infographic.json](docs/day3_infographic.json)**  
-  Open in Colab → **[render_infographic.ipynb](https://colab.research.google.com/github/derekwins88/Brain/blob/main/notebooks/render_infographic.ipynb)**
-
-_Re-render locally:_
+### Reproduce locally
 
 ```bash
-python -m nbconvert --to notebook --execute \
-  notebooks/render_infographic.ipynb \
-  --output /tmp/render_output.ipynb
+# 1) Bench (small/fast)
+python bench.py --traces 1_000_000 --mode cpu  -o out/bench_1M_cpu.csv
+python bench.py --traces 1_000_000 --mode auto -o out/bench_1M_auto.csv   # auto = GPU if present
+
+# 2) Plot chart from CSVs
+python plot_bench.py out/bench_*.csv -o gallery/day4_bench.png
+
+# 3) Build gallery page
+python gallery.py --capsules out/*.json --theme dark --out docs/gallery.html
 ```
 
-Or trigger the Auto-render infographic GitHub Action to refresh docs/day3_infographic.png automatically.
-
-> Tip: in Colab, **Runtime → Run all**. The notebook writes `docs/day3_infographic.png` back into the repo tree for an easy PR.
-
----
+CI: The “CI – Bench” job compiles Python, runs a small bench, renders gallery/day4_bench.png, builds docs/gallery.html, uploads them as artifacts, and (optionally) commits updates.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- add top-level CI badge row covering Python, .NET, Lean4, capsules, data, infographic, and bench jobs
- document Day-4 benchmark & gallery workflow with local reproduction steps
- introduce `ci-bench` workflow that benchmarks traces, renders chart, builds gallery, and uploads artifacts

## Testing
- `pre-commit run --files README.md .github/workflows/ci-bench.yml` *(fails: prompts for GitHub credentials)*
- `pytest -q`
- `dotnet test` *(fails: command not found)*

Story: This update funnels benchmark traces into the capsule gallery so entropy throughput doesn’t drift unseen.

------
https://chatgpt.com/codex/tasks/task_e_68c5e175319c8320991a9778d0b2d752