### PR TITLE
Fix infographic timestamp field

### DIFF
--- a/notebooks/render_infographic.ipynb
+++ b/notebooks/render_infographic.ipynb
@@ -1,110 +1,123 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Day-3 Infographic renderer\n",
-    "\n",
-    "Reads `docs/day3_infographic.json` and writes `docs/day3_infographic.png`.\n",
-    "\n",
-    "Works in Colab and local dev. No special fonts, no theme packages."
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Day-3 Infographic renderer\n",
+        "\n",
+        "Reads `docs/day3_infographic.json` and writes `docs/day3_infographic.png`.\n",
+        "\n",
+        "Works in Colab and local dev. No special fonts, no theme packages."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import json, os, datetime as dt\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "ROOT = os.path.abspath(os.path.join(os.getcwd(), '..')) if os.path.basename(os.getcwd()) == 'notebooks' else os.getcwd()\n",
+        "JSON_PATH = os.environ.get('INFO_JSON', os.path.join(ROOT, 'docs', 'day3_infographic.json'))\n",
+        "with open(JSON_PATH) as f:\n",
+        "    meta = json.load(f)\n",
+        "\n",
+        "PNG_PATH = os.environ.get('INFO_PNG', os.path.join(ROOT, 'docs', 'day3_infographic.png'))\n",
+        "\n",
+        "if meta.get('timestamp') == '{{AUTO}}':\n",
+        "    meta['timestamp'] = dt.datetime.utcnow().isoformat(timespec='seconds') + 'Z'\n",
+        "\n",
+        "title = meta.get('title', 'Infographic')\n",
+        "subtitle = meta.get('subtitle', '')\n",
+        "m = meta.get('metrics', {})\n",
+        "notes = meta.get('notes', [])\n",
+        "visuals = meta.get('visuals', {})\n",
+        "palette = visuals.get('palette', [])\n",
+        "accent = palette[0] if palette else None\n",
+        "bg = palette[1] if len(palette) > 1 else None\n",
+        "\n",
+        "# --- Layout ---------------------------------------------------------------\n",
+        "fig = plt.figure(figsize=(10, 6), dpi=160)\n",
+        "ax = plt.gca()\n",
+        "ax.axis('off')\n",
+        "\n",
+        "if bg:\n",
+        "    fig.patch.set_facecolor(bg)\n",
+        "    ax.set_facecolor(bg)\n",
+        "\n",
+        "def T(x, size=14, weight='normal', color=None, y=None):\n",
+        "    return ax.text(0.05, y, x, transform=ax.transAxes, fontsize=size,\n",
+        "                   fontweight=weight, color=color)\n",
+        "\n\n",
+        "T(title, size=20, weight='bold', color=accent, y=0.92)\n",
+        "T(subtitle, size=12, color=(0.8,0.8,0.85), y=0.87)\n",
+        "\n",
+        "lines = [\n",
+        "f\"NP-wall rate: {m.get('np_wall_pct', 0):.2f}%\",\n",
+        "f\"\u0394\u03a6 threshold (NP): {m.get('np_threshold','?')}\",\n",
+        "f\"\u0394\u03a6 threshold (P):  {m.get('p_threshold','?')}\",\n",
+        "f\"Samples \u00d7 length:  {m.get('samples','?')} \u00d7 {m.get('trace_len','?')}\"\n",
+        "]\n",
+        "y = 0.75\n",
+        "for s in lines:\n",
+        "    T(s, size=14, color='white', y=y)\n",
+        "    y -= 0.06\n",
+        "\n",
+        "T('Notes:', size=14, weight='bold', color=accent, y=y - 0.02)\n",
+        "y -= 0.10\n",
+        "for h in notes:\n",
+        "    T('\u2022 ' + h, size=13, color='white', y=y)\n",
+        "    y -= 0.05\n",
+        "\n",
+        "T(f\"Created: {meta['timestamp']}\", size=9, color=(0.7,0.72,0.8), y=0.06)\n",
+        "\n",
+        "os.makedirs(os.path.dirname(PNG_PATH), exist_ok=True)\n",
+        "plt.savefig(PNG_PATH, bbox_inches='tight')\n",
+        "print(f'Saved \u2192 {PNG_PATH}')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "tags": [
+          "parameters"
+        ]
+      },
+      "outputs": [],
+      "source": [
+        "# Optional: quick view in notebook\n",
+        "from IPython.display import Image, display\n",
+        "display(Image(filename=PNG_PATH))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Notes\n",
+        "- Edit numbers in `docs/day3_infographic.json` or point `INFO_JSON` env to another file.\n",
+        "- CI can set INFO_JSON/INFO_PNG to render alternative outputs."
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "render_infographic.ipynb"
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import json, os, datetime as dt\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "ROOT = os.path.abspath(os.path.join(os.getcwd(), '..')) if os.path.basename(os.getcwd()) == 'notebooks' else os.getcwd()\n",
-    "JSON_PATH = os.environ.get('INFO_JSON', os.path.join(ROOT, 'docs', 'day3_infographic.json'))\n",
-    "with open(JSON_PATH) as f:\n",
-    "    meta = json.load(f)\n",
-    "\n",
-    "PNG_PATH = os.environ.get('INFO_PNG', os.path.join(ROOT, 'docs', 'day3_infographic.png'))\n",
-    "\n",
-    "if meta.get('created_at') == '{{AUTO}}':\n",
-    "    meta['created_at'] = dt.datetime.utcnow().isoformat(timespec='seconds') + 'Z'\n",
-    "\n",
-    "title = meta.get('title', 'Infographic')\n",
-    "subtitle = meta.get('subtitle', '')\n",
-    "m = meta.get('metrics', {})\n",
-    "notes = meta.get('notes', [])\n",
-    "visuals = meta.get('visuals', {})\n",
-    "palette = visuals.get('palette', [])\n",
-    "accent = palette[0] if palette else None\n",
-    "bg = palette[1] if len(palette) > 1 else None\n",
-    "\n",
-    "# --- Layout ---------------------------------------------------------------\n",
-    "fig = plt.figure(figsize=(10, 6), dpi=160)\n",
-    "ax = plt.gca()\n",
-    "ax.axis('off')\n",
-    "\n",
-    "if bg:\n",
-    "    fig.patch.set_facecolor(bg)\n",
-    "    ax.set_facecolor(bg)\n",
-    "\n",
-    "def T(x, size=14, weight='normal', color=None, y=None):\n",
-    "    return ax.text(0.05, y, x, transform=ax.transAxes, fontsize=size,\n",
-    "                   fontweight=weight, color=color)\n",
-    "\n\n",
-    "T(title, size=20, weight='bold', color=accent, y=0.92)\n",
-    "T(subtitle, size=12, color=(0.8,0.8,0.85), y=0.87)\n",
-    "\n",
-    "lines = [\n",
-    "f\"NP-wall rate: {m.get('np_wall_pct', 0):.2f}%\",\n",
-    "f\"ΔΦ threshold (NP): {m.get('np_threshold','?')}\",\n",
-    "f\"ΔΦ threshold (P):  {m.get('p_threshold','?')}\",\n",
-    "f\"Samples × length:  {m.get('samples','?')} × {m.get('trace_len','?')}\"\n",
-    "]\n",
-    "y = 0.75\n",
-    "for s in lines:\n",
-    "    T(s, size=14, color='white', y=y)\n",
-    "    y -= 0.06\n",
-    "\n",
-    "T('Notes:', size=14, weight='bold', color=accent, y=y - 0.02)\n",
-    "y -= 0.10\n",
-    "for h in notes:\n",
-    "    T('• ' + h, size=13, color='white', y=y)\n",
-    "    y -= 0.05\n",
-    "\n",
-    "T(f\"Created: {meta['created_at']}\", size=9, color=(0.7,0.72,0.8), y=0.06)\n",
-    "\n",
-    "os.makedirs(os.path.dirname(PNG_PATH), exist_ok=True)\n",
-    "plt.savefig(PNG_PATH, bbox_inches='tight')\n",
-    "print(f'Saved → {PNG_PATH}')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {"tags": ["parameters"]},
-   "outputs": [],
-   "source": [
-    "# Optional: quick view in notebook\n",
-    "from IPython.display import Image, display\n",
-    "display(Image(filename=PNG_PATH))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Notes\n",
-    "- Edit numbers in `docs/day3_infographic.json` or point `INFO_JSON` env to another file.\n",
-    "- CI can set INFO_JSON/INFO_PNG to render alternative outputs."
-   ]
-  }
- ],
- "metadata": {
-  "colab": {"name": "render_infographic.ipynb"},
-  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
-  "language_info": {"name": "python", "version": "3"}
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- align infographic notebook with schema by using `timestamp` metadata

## Testing
- `python -m nbconvert --to notebook --execute --ExecutePreprocessor.allow_errors=True notebooks/render_infographic.ipynb --output /tmp/render_output.ipynb`
- `python - <<'PY'\nimport json, jsonschema\nschema=json.load(open('schema/infographic.schema.json'))\ndata=json.load(open('docs/day3_infographic.json'))\njsonschema.validate(data, schema); print('JSON OK')\nPY`
- `GIT_TERMINAL_PROMPT=0 pre-commit run --files notebooks/render_infographic.ipynb` *(fails: prompts for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68c6494545b48320a951b918f13c01c5