### PR TITLE
Fix infographic timestamp field

### DIFF
--- a/.github/workflows/auto_render_infographic.yml
+++ b/.github/workflows/auto_render_infographic.yml
@@ -1,13 +1,18 @@
 name: CI - Infographic / render
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     paths:
       - "notebooks/render_infographic.ipynb"
-      - "docs/day3_infographic.json"
       - "schema/infographic.schema.json"
+      - "docs/day3_infographic.json"
+      - ".github/workflows/auto_render_infographic.yml"
+  push:
+    branches: [ "main" ]
+    paths:
+      - "notebooks/render_infographic.ipynb"
+      - "schema/infographic.schema.json"
+      - "docs/day3_infographic.json"
       - ".github/workflows/auto_render_infographic.yml"
   workflow_dispatch:
 
@@ -15,8 +20,8 @@ jobs:
   render:
     runs-on: ubuntu-latest
     env:
-      # PRs run in "SMOKE" mode (skip hard validation, allow notebook to render)
-      SMOKE: ${{ github.event_name == 'pull_request' && '1' || '0' }}
+      # PRs = SMOKE; main push/dispatch = strict
+      SMOKE: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -28,35 +33,53 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          python -m pip install nbconvert nbclient jupyter jsonschema matplotlib pillow
+          python -m pip install jupyter nbconvert jsonschema pillow matplotlib
 
-      - name: Validate infographic JSON against schema (skipped in SMOKE)
-        if: env.SMOKE != '1'
+      - name: Ensure folders
+        run: mkdir -p docs /tmp
+
+      # Run the notebook headlessly. In SMOKE mode we allow cell errors so we
+      # still get a fresh PNG even if optional data is missing.
+      - name: Execute notebook (SMOKE-aware)
         run: |
-          if [ ! -f schema/infographic.schema.json ] || [ ! -f docs/day3_infographic.json ]; then
-            echo "Schema or JSON missing, skipping validation."
-            exit 0
+          if [ "${SMOKE}" = "true" ]; then
+            echo "SMOKE mode: allow notebook errors"
+            python -m nbconvert --to notebook --execute \
+              --ExecutePreprocessor.allow_errors=True \
+              --output /tmp/render_out.ipynb \
+              notebooks/render_infographic.ipynb
+          else
+            echo "STRICT mode: fail on notebook errors"
+            python -m nbconvert --to notebook --execute \
+              --output /tmp/render_out.ipynb \
+              notebooks/render_infographic.ipynb
           fi
-          python - <<'PY'
-import json, jsonschema, sys
-schema = json.load(open('schema/infographic.schema.json'))
-data   = json.load(open('docs/day3_infographic.json'))
-jsonschema.validate(data, schema)
-print("✅ JSON schema validation passed")
-PY
 
-      - name: Execute notebook (headless)
+      # Optional JSON validation: only strict on main (SMOKE=false).
+      - name: Validate infographic JSON (strict on main)
         run: |
-          # allow_errors keeps the PNG step alive in smoke situations
-          python -m nbconvert --to notebook --execute \
-            --ExecutePreprocessor.allow_errors=True \
-            notebooks/render_infographic.ipynb \
-            --output /tmp/render_output.ipynb
+          if [ "${SMOKE}" = "true" ]; then
+            echo "SMOKE mode: skipping strict JSON validation"
+          else
+            python tools/validate_infographic.py schema/infographic.schema.json docs/day3_infographic.json
+          fi
 
-      - name: Upload artifact
+      - name: Upload PNG artifact
         uses: actions/upload-artifact@v4
         with:
-          name: day3-infographic
-          path: |
-            docs/day3_infographic.png
-            docs/day3_infographic.json
+          name: day3-infographic-png
+          path: docs/day3_infographic.png
+          if-no-files-found: warn
+
+      - name: Commit updated PNG (main only, when changed)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/day3_infographic.png || true
+          if ! git diff --staged --quiet; then
+            git commit -m "chore(ci): auto-update day3 infographic"
+            git push
+          else
+            echo "No PNG changes to commit."
+          fi

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Turn **harmonic entropy drift** into **machine-checkable Pâ‰ NP artifacts** in â
   Metadata: [docs/day3_infographic.json](./docs/day3_infographic.json) *(optional)*
   Open in Colab: https://colab.research.google.com/github/derekwins88/Brain/blob/main/notebooks/render_infographic.ipynb
 
-> **Tip:** On PRs, the infographic CI runs in **SMOKE** mode (skips strict JSON validation and allows soft notebook errors) so the PNG continues to refresh. On `main`, full validation is enforced.
-
+> **CI behavior:** On pull requests the *Infographic* job runs in **SMOKE** mode  
+> (renders the notebook and PNG even if optional metadata is missing).  
+> On `main`, strict JSON validation and hard-fail are enforced.
 Local full check:
 ```bash
 python -m nbconvert --to notebook --execute notebooks/render_infographic.ipynb --output /tmp/render_out.ipynb

--- a/notebooks/render_infographic.ipynb
+++ b/notebooks/render_infographic.ipynb
@@ -1,110 +1,123 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Day-3 Infographic renderer\n",
-    "\n",
-    "Reads `docs/day3_infographic.json` and writes `docs/day3_infographic.png`.\n",
-    "\n",
-    "Works in Colab and local dev. No special fonts, no theme packages."
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Day-3 Infographic renderer\n",
+        "\n",
+        "Reads `docs/day3_infographic.json` and writes `docs/day3_infographic.png`.\n",
+        "\n",
+        "Works in Colab and local dev. No special fonts, no theme packages."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import json, os, datetime as dt\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "ROOT = os.path.abspath(os.path.join(os.getcwd(), '..')) if os.path.basename(os.getcwd()) == 'notebooks' else os.getcwd()\n",
+        "JSON_PATH = os.environ.get('INFO_JSON', os.path.join(ROOT, 'docs', 'day3_infographic.json'))\n",
+        "with open(JSON_PATH) as f:\n",
+        "    meta = json.load(f)\n",
+        "\n",
+        "PNG_PATH = os.environ.get('INFO_PNG', os.path.join(ROOT, 'docs', 'day3_infographic.png'))\n",
+        "\n",
+        "if meta.get('timestamp') == '{{AUTO}}':\n",
+        "    meta['timestamp'] = dt.datetime.utcnow().isoformat(timespec='seconds') + 'Z'\n",
+        "\n",
+        "title = meta.get('title', 'Infographic')\n",
+        "subtitle = meta.get('subtitle', '')\n",
+        "m = meta.get('metrics', {})\n",
+        "notes = meta.get('notes', [])\n",
+        "visuals = meta.get('visuals', {})\n",
+        "palette = visuals.get('palette', [])\n",
+        "accent = palette[0] if palette else None\n",
+        "bg = palette[1] if len(palette) > 1 else None\n",
+        "\n",
+        "# --- Layout ---------------------------------------------------------------\n",
+        "fig = plt.figure(figsize=(10, 6), dpi=160)\n",
+        "ax = plt.gca()\n",
+        "ax.axis('off')\n",
+        "\n",
+        "if bg:\n",
+        "    fig.patch.set_facecolor(bg)\n",
+        "    ax.set_facecolor(bg)\n",
+        "\n",
+        "def T(x, size=14, weight='normal', color=None, y=None):\n",
+        "    return ax.text(0.05, y, x, transform=ax.transAxes, fontsize=size,\n",
+        "                   fontweight=weight, color=color)\n",
+        "\n\n",
+        "T(title, size=20, weight='bold', color=accent, y=0.92)\n",
+        "T(subtitle, size=12, color=(0.8,0.8,0.85), y=0.87)\n",
+        "\n",
+        "lines = [\n",
+        "f\"NP-wall rate: {m.get('np_wall_pct', 0):.2f}%\",\n",
+        "f\"\u0394\u03a6 threshold (NP): {m.get('np_threshold','?')}\",\n",
+        "f\"\u0394\u03a6 threshold (P):  {m.get('p_threshold','?')}\",\n",
+        "f\"Samples \u00d7 length:  {m.get('samples','?')} \u00d7 {m.get('trace_len','?')}\"\n",
+        "]\n",
+        "y = 0.75\n",
+        "for s in lines:\n",
+        "    T(s, size=14, color='white', y=y)\n",
+        "    y -= 0.06\n",
+        "\n",
+        "T('Notes:', size=14, weight='bold', color=accent, y=y - 0.02)\n",
+        "y -= 0.10\n",
+        "for h in notes:\n",
+        "    T('\u2022 ' + h, size=13, color='white', y=y)\n",
+        "    y -= 0.05\n",
+        "\n",
+        "T(f\"Created: {meta['timestamp']}\", size=9, color=(0.7,0.72,0.8), y=0.06)\n",
+        "\n",
+        "os.makedirs(os.path.dirname(PNG_PATH), exist_ok=True)\n",
+        "plt.savefig(PNG_PATH, bbox_inches='tight')\n",
+        "print(f'Saved \u2192 {PNG_PATH}')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "tags": [
+          "parameters"
+        ]
+      },
+      "outputs": [],
+      "source": [
+        "# Optional: quick view in notebook\n",
+        "from IPython.display import Image, display\n",
+        "display(Image(filename=PNG_PATH))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Notes\n",
+        "- Edit numbers in `docs/day3_infographic.json` or point `INFO_JSON` env to another file.\n",
+        "- CI can set INFO_JSON/INFO_PNG to render alternative outputs."
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "render_infographic.ipynb"
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import json, os, datetime as dt\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "ROOT = os.path.abspath(os.path.join(os.getcwd(), '..')) if os.path.basename(os.getcwd()) == 'notebooks' else os.getcwd()\n",
-    "JSON_PATH = os.environ.get('INFO_JSON', os.path.join(ROOT, 'docs', 'day3_infographic.json'))\n",
-    "with open(JSON_PATH) as f:\n",
-    "    meta = json.load(f)\n",
-    "\n",
-    "PNG_PATH = os.environ.get('INFO_PNG', os.path.join(ROOT, 'docs', 'day3_infographic.png'))\n",
-    "\n",
-    "if meta.get('created_at') == '{{AUTO}}':\n",
-    "    meta['created_at'] = dt.datetime.utcnow().isoformat(timespec='seconds') + 'Z'\n",
-    "\n",
-    "title = meta.get('title', 'Infographic')\n",
-    "subtitle = meta.get('subtitle', '')\n",
-    "m = meta.get('metrics', {})\n",
-    "notes = meta.get('notes', [])\n",
-    "visuals = meta.get('visuals', {})\n",
-    "palette = visuals.get('palette', [])\n",
-    "accent = palette[0] if palette else None\n",
-    "bg = palette[1] if len(palette) > 1 else None\n",
-    "\n",
-    "# --- Layout ---------------------------------------------------------------\n",
-    "fig = plt.figure(figsize=(10, 6), dpi=160)\n",
-    "ax = plt.gca()\n",
-    "ax.axis('off')\n",
-    "\n",
-    "if bg:\n",
-    "    fig.patch.set_facecolor(bg)\n",
-    "    ax.set_facecolor(bg)\n",
-    "\n",
-    "def T(x, size=14, weight='normal', color=None, y=None):\n",
-    "    return ax.text(0.05, y, x, transform=ax.transAxes, fontsize=size,\n",
-    "                   fontweight=weight, color=color)\n",
-    "\n\n",
-    "T(title, size=20, weight='bold', color=accent, y=0.92)\n",
-    "T(subtitle, size=12, color=(0.8,0.8,0.85), y=0.87)\n",
-    "\n",
-    "lines = [\n",
-    "f\"NP-wall rate: {m.get('np_wall_pct', 0):.2f}%\",\n",
-    "f\"ΔΦ threshold (NP): {m.get('np_threshold','?')}\",\n",
-    "f\"ΔΦ threshold (P):  {m.get('p_threshold','?')}\",\n",
-    "f\"Samples × length:  {m.get('samples','?')} × {m.get('trace_len','?')}\"\n",
-    "]\n",
-    "y = 0.75\n",
-    "for s in lines:\n",
-    "    T(s, size=14, color='white', y=y)\n",
-    "    y -= 0.06\n",
-    "\n",
-    "T('Notes:', size=14, weight='bold', color=accent, y=y - 0.02)\n",
-    "y -= 0.10\n",
-    "for h in notes:\n",
-    "    T('• ' + h, size=13, color='white', y=y)\n",
-    "    y -= 0.05\n",
-    "\n",
-    "T(f\"Created: {meta['created_at']}\", size=9, color=(0.7,0.72,0.8), y=0.06)\n",
-    "\n",
-    "os.makedirs(os.path.dirname(PNG_PATH), exist_ok=True)\n",
-    "plt.savefig(PNG_PATH, bbox_inches='tight')\n",
-    "print(f'Saved → {PNG_PATH}')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {"tags": ["parameters"]},
-   "outputs": [],
-   "source": [
-    "# Optional: quick view in notebook\n",
-    "from IPython.display import Image, display\n",
-    "display(Image(filename=PNG_PATH))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Notes\n",
-    "- Edit numbers in `docs/day3_infographic.json` or point `INFO_JSON` env to another file.\n",
-    "- CI can set INFO_JSON/INFO_PNG to render alternative outputs."
-   ]
-  }
- ],
- "metadata": {
-  "colab": {"name": "render_infographic.ipynb"},
-  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
-  "language_info": {"name": "python", "version": "3"}
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/tools/validate_infographic.py
+++ b/tools/validate_infographic.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import json
+import sys
+from jsonschema import validate, ValidationError
+
+
+def main(schema_path: str, data_path: str) -> None:
+    try:
+        with open(schema_path, "r", encoding="utf-8") as f:
+            schema = json.load(f)
+        with open(data_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError as e:
+        print(f"[validate] Missing file: {e.filename}")
+        sys.exit(1)
+
+    try:
+        validate(instance=data, schema=schema)
+        print("[validate] JSON OK ✔")
+    except ValidationError as e:
+        print("[validate] JSON schema validation failed ❌")
+        print("Path :", list(e.path))
+        print("Error:", e.message)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: tools/validate_infographic.py <schema.json> <data.json>")
+        sys.exit(2)
+    main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
## Summary
- align infographic notebook with schema by using `timestamp` metadata
- harden auto infographic workflow with SMOKE mode and explicit validation script

## Testing
- `python -m nbconvert --to notebook --execute --ExecutePreprocessor.allow_errors=True notebooks/render_infographic.ipynb --output /tmp/render_output.ipynb`
- `python tools/validate_infographic.py schema/infographic.schema.json docs/day3_infographic.json`
- `GIT_TERMINAL_PROMPT=0 pre-commit run --files .github/workflows/auto_render_infographic.yml tools/validate_infographic.py README.md` *(fails: prompts for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68c6494545b48320a951b918f13c01c5