### PR TITLE
fix(ci): don’t fail render on commit 403; document token setting

### DIFF
--- a/.github/workflows/auto_render_infographic.yml
+++ b/.github/workflows/auto_render_infographic.yml
@@ -101,9 +101,11 @@ PY
         path: docs/day3_infographic.png
         if-no-files-found: warn
 
-    # ✅ Push back only on main (PRs skip); use the GITHUB_TOKEN and explicit perms
+    # ✅ Push back only on main (PRs skip). If token/branch rules block the push,
+    # don’t fail the job (badge stays green) – we already uploaded the artifact.
     - name: Commit updated PNG (main only, when changed)
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      continue-on-error: true
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: ${{ github.ref_name }}
@@ -112,15 +114,14 @@ PY
         set -e
         git config user.name  "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-        # Stage and commit only if changed
         git add docs/day3_infographic.png || true
         if git diff --staged --quiet; then
           echo "No PNG changes to commit."
           exit 0
         fi
-
         git commit -m "chore(ci): auto-update day3 infographic"
-        # Push via token-auth URL to avoid 403
-        git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}" "HEAD:${BRANCH}"
+        # Push via token-auth URL. If this 403s (permissions/branch rules), don’t fail the job.
+        if ! git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}" "HEAD:${BRANCH}"; then
+          echo "⚠️ Push skipped (likely branch protection or read-only token)."
+        fi
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 ![CI - Bench](https://github.com/derekwins88/Brain/actions/workflows/ci-bench.yml/badge.svg)
 <!-- DOI badge placeholder; will activate after first Zenodo release -->
 [![DOI](https://img.shields.io/badge/DOI-pending-lightgrey.svg)](#)
+> **Infographic CI note:** On PRs we run in SMOKE mode and always upload a PNG artifact.  
+> On `main`, the workflow will try to commit the refreshed PNG. If repo **Settings → Actions → Workflow permissions**
+> is set to **Read and write**, the bot push succeeds; if not (or if branch protection blocks it), the step is
+> allowed to fail gracefully and the workflow still passes. The latest PNG is always available as the run artifact.
+
 
 **Status:** Day-1 green ✅ — Python, .NET, Lean4 build pass; Proof v1.1 pipeline smoke passes (PDF check is permissive until full translator is wired).
 


### PR DESCRIPTION
## Summary
- prevent the infographic render workflow from failing when token/branch rules block committing the PNG
- document required workflow permissions and fallback artifact behaviour in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'brain')*
- `python -m pip install -e .` *(fails: Multiple top-level packages discovered in a flat-layout)*

------
https://chatgpt.com/codex/tasks/task_e_68c66b375a80832087c67bff06bc8a50