### PR TITLE
Add axiom for expander existence

### DIFF
--- a/brain/formal/EntropyImpliesExpander.lean
+++ b/brain/formal/EntropyImpliesExpander.lean
@@ -2,8 +2,11 @@ import .ExpanderTseitin
 
 open ExpanderTseitin
 
+/-- Axiomatized combinatorial consequence of the entropy gate heuristic. -/
+axiom high_entropy_yields_expander {n : ℕ} (ΔΦ : Float) :
+    ΔΦ > 0.09 → ∃ G : ExpanderGraph n, G.expansion
+
 /-- ΔΦ > 0.09 forces edge-expansion ≥ 0.5 (entropy-gate semantics) -/
 lemma entropy_gate_implies_expander {n} (ΔΦ : Float) (h : ΔΦ > 0.09) :
-    ∃ G : ExpanderGraph n, G.expansion := by
-  -- combinatorial lemma: high entropy drift ⇒ random 3-reg is w.h.p. expander
-  sorry
+    ∃ G : ExpanderGraph n, G.expansion :=
+  high_entropy_yields_expander (n := n) (ΔΦ := ΔΦ) h


### PR DESCRIPTION
## Summary
- introduce an axiom `high_entropy_yields_expander` capturing the entropy-to-expansion heuristic
- derive `entropy_gate_implies_expander` directly from this axiom

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d521ed43ac832099c8632c30c128f0