### PR TITLE
Add Lean 4 proof CI workflow

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -1,0 +1,17 @@
+name: Lean 4 Proof Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lean:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: leanprover/lean-action@v1
+        with:
+          project: brain/formal
+          args: lake build PvsNP


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run Lean 4 proof checks on main pushes and pull requests
- build the `PvsNP` target from the `brain/formal` project using the Lean prover action

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d52641ace88320b06b3c0c2ec1cd7c