### PR TITLE
Add entropy lemma for LPS Tseitin formulas

### DIFF
--- a/brain/formal/EntropyExact.lean
+++ b/brain/formal/EntropyExact.lean
@@ -1,0 +1,12 @@
+import .LPSExpander
+import .ExpanderTseitin
+
+open LPSExpander ExpanderTseitin
+
+/-- Closed-form entropy drift for LPS-Tseitin formulas -/
+lemma entropy_LPS (n : ℕ) (hn : ∃ p, Nat.Prime p ∧ p % 4 = 1 ∧ n = p + 1 ∧ p ≥ 17) :
+    ΔΦ (tseitinCnf (explicitExpander n hn)) > 0.09 := by
+  -- compute clause/variable ratio and apply the curvature lemma
+  have ratio := LPS.clause_variable_ratio n hn
+  have curvature := entropy_curvature ratio
+  linarith


### PR DESCRIPTION
## Summary
- add a lemma stating a positive entropy drift for explicit LPS Tseitin formulas
- leverage existing clause-variable ratio and entropy curvature results to conclude the bound

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66e9d9e888320a5cce65f77490f19