### PR TITLE
Update mathlib dependency to v4.12.0

### DIFF
--- a/lean/lakefile.lean
+++ b/lean/lakefile.lean
@@ -8,4 +8,4 @@ package «brain» where
   -- buildArgs := #["-Werror"]
 
 require mathlib from git
-  "https://github.com/leanprover-community/mathlib4.git"
+  "https://github.com/leanprover-community/mathlib4.git" @ "v4.12.0"


### PR DESCRIPTION
## Summary
- pin the mathlib dependency to the v4.12.0 release

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d670ecac78832083adf49bac9c5f68