### PR TITLE
Update LPS expander imports for mathlib 4.12

### DIFF
--- a/brain/formal/ExpanderTseitin.lean
+++ b/brain/formal/ExpanderTseitin.lean
@@ -10,7 +10,7 @@ namespace ExpanderTseitin
 structure ExpanderGraph (n : ℕ) where
   simpleGraph : SimpleGraph (Fin n)
   regular     : ∀ v, simpleGraph.degree v = 3
-  expansion   : simpleGraph.edgeExpander ≥ 5 / 10
+  expansion   : simpleGraph.edgeExpansion ≥ 5 / 10
 
 /-- Tseitin CNF with odd charge -/
 def tseitinCnf {n} (G : ExpanderGraph n) : CnfForm :=

--- a/brain/formal/LPSExpander.lean
+++ b/brain/formal/LPSExpander.lean
@@ -1,5 +1,5 @@
+import Mathlib.Combinatorics.Graph.Ramanujan.LPS
 import Mathlib.Combinatorics.Graph.Expander
-import Mathlib.NumberTheory.RamanujanGraphs.LPS
 
 open SimpleGraph
 
@@ -12,10 +12,10 @@ namespace LPSExpander
 
 /-- The edge-expansion of the LPS graphs is at least `0.5` for `p ≥ 17`. -/
 lemma lps_expansion (p : ℕ) (hp : Nat.Prime p) (hmod : p % 4 = 1) (hge : p ≥ 17) :
-    edgeExpander (lpsGraph p hp hmod) ≥ 5 / 10 := by
+    edgeExpansion (lpsGraph p hp hmod) ≥ 5 / 10 := by
   have := LPS.lambda_two_bound p hp hmod
   -- Ramanujan ⇒ `λ₂ ≤ 2√3`, hence the stated edge-expansion bound.
-  simpa using LPS.edgeExpander_le_of_lambda_two_le (p := p) (hp := hp) (hmod := hmod) hge this
+  simpa using LPS.edgeExpansion_le_of_lambda_two_le (p := p) (hp := hp) (hmod := hmod) hge this
 
 /-- The LPS graphs are 3-regular by construction. -/
 lemma lps_regular (p : ℕ) (hp : Nat.Prime p) (hmod : p % 4 = 1) :


### PR DESCRIPTION
## Summary
- switch the LPS expander module to the new `Mathlib.Combinatorics.Graph.Ramanujan.LPS` namespace
- update usages of the renamed `edgeExpansion` lemma and structure field to match mathlib 4.12

## Testing
- lake build PvsNP *(fails: `lake` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d674c0df588320aee06a98dd6d8bc3