### PR TITLE
Fix notes Makefile targets and Lean toolchain install

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -15,7 +15,9 @@ jobs:
         run: |
           curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | bash -s -- -y
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
-          ~/.elan/bin/elan toolchain link default "$(cat lean/lean-toolchain)"
+          TOOLCHAIN="$(cat lean/lean-toolchain)"
+          ~/.elan/bin/elan toolchain install "$TOOLCHAIN"
+          ~/.elan/bin/elan default "$TOOLCHAIN"
       - uses: leanprover/lean-action@v1
         with:
           project: brain/formal

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-.PHONY: docs serve clean
+.PHONY: docs serve clean notes-setup notes-diagram notes-docs
 
+# --- mdBook core ---
 docs:
 	cargo install mdbook --version 0.4.40 --locked || true
 	cargo install mdbook-mermaid --version 0.13.0 --locked || true
@@ -12,3 +13,16 @@ serve:
 
 clean:
 	rm -rf book
+
+# --- Notes pipeline compatibility (what your CI calls) ---
+notes-setup:
+	cargo install mdbook --version 0.4.40 --locked || true
+	cargo install mdbook-mermaid --version 0.13.0 --locked || true
+
+# If you later render standalone diagrams, hook it here.
+# For now, let mdBook-mermaid handle diagrams during build.
+notes-diagram:
+	@echo "notes-diagram: handled by mdBook-mermaid during build"
+
+notes-docs: notes-setup
+	mdbook build


### PR DESCRIPTION
## Summary
- add the notes-* targets to the Makefile so docs workflows can call them
- install and select the Lean toolchain from `lean/lean-toolchain` in CI instead of linking directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6fa53fbec83209e9f364f33732aee