### PR TITLE
ci(lean): run in ./lean and generate manifest

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -1,24 +1,38 @@
 name: Lean 4 Proof Check
-
 on:
   push:
     branches: [ main ]
+    paths: [ 'lean/**', '.github/workflows/lean.yml' ]
   pull_request:
-    branches: [ main ]
+    paths: [ 'lean/**', '.github/workflows/lean.yml' ]
 
 jobs:
   lean:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Lean toolchain
+
+      - name: Install Elan (Lean toolchain)
         run: |
           curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | bash -s -- -y
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
           TOOLCHAIN="$(cat lean/lean-toolchain)"
           ~/.elan/bin/elan toolchain install "$TOOLCHAIN"
           ~/.elan/bin/elan default "$TOOLCHAIN"
-      - uses: leanprover/lean-action@v1
+
+      - name: Cache Lake deps
+        uses: actions/cache@v4
         with:
-          project: brain/formal
-          args: lake build PvsNP
+          path: |
+            ~/.elan
+            ~/.lake
+          key: ${{ runner.os }}-lake-${{ hashFiles('lean/lakefile.lean', 'lean/lake-manifest.json') }}
+          restore-keys: ${{ runner.os }}-lake-
+
+      - name: lake update (generates lake-manifest.json)
+        working-directory: lean
+        run: lake update
+
+      - name: lake build
+        working-directory: lean
+        run: lake build

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![CI - Python](https://github.com/derekwins88/Brain/actions/workflows/ci-python.yml/badge.svg?branch=main)
 ![CI - .NET](https://github.com/derekwins88/Brain/actions/workflows/ci-dotnet.yml/badge.svg?branch=main)
-![CI - Lean4](https://github.com/derekwins88/Brain/actions/workflows/ci-lean.yml/badge.svg?branch=main)
+![CI - Lean4](https://github.com/derekwins88/Brain/actions/workflows/lean.yml/badge.svg?branch=main)
 ![CI - Proof v1.1 (smoke)](https://github.com/derekwins88/Brain/actions/workflows/ci-proof.yml/badge.svg?branch=main)
 ![CI - Capsules](https://github.com/derekwins88/Brain/actions/workflows/ci-capsules.yml/badge.svg?branch=main)
 ![CI - Data](https://github.com/derekwins88/Brain/actions/workflows/ci-data.yml/badge.svg?branch=main)
@@ -67,7 +67,7 @@ PY
 
 ![CI - Python](https://github.com/derekwins88/Brain/actions/workflows/ci-python.yml/badge.svg?branch=main)
 ![CI - .NET](https://github.com/derekwins88/Brain/actions/workflows/ci-dotnet.yml/badge.svg?branch=main)
-![CI - Lean4](https://github.com/derekwins88/Brain/actions/workflows/ci-lean.yml/badge.svg?branch=main)
+![CI - Lean4](https://github.com/derekwins88/Brain/actions/workflows/lean.yml/badge.svg?branch=main)
 ![CI - Proof](https://github.com/derekwins88/Brain/actions/workflows/ci-proof.yml/badge.svg?branch=main)
 ![CI - Capsules](https://github.com/derekwins88/Brain/actions/workflows/ci-capsules.yml/badge.svg?branch=main)
 


### PR DESCRIPTION
## Summary
- run the Lean CI workflow inside the `lean/` directory and add an explicit `lake update` step before `lake build`
- cache elan and Lake dependencies keyed on the lake manifest inputs
- update the README badges to point at the new `lean.yml` workflow

## Testing
- not run (CI only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d700a8f21c8320b4300d5f90b2c7ce